### PR TITLE
Fix: PHP 8.2 compatibility

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -36,6 +36,7 @@ require_once($CFG->dirroot . '/mod/offlinequiz/pdflib.php');
 
 class offlinequiz_answer_pdf_identified extends offlinequiz_answer_pdf {
     public $participant = null;
+    public $listno = null;
 
     public function Header(){
         global $CFG, $DB;


### PR DESCRIPTION
The plugin doesn't work on php 8.2 with warnings enabled, because the download produces a warning, that the class offlinequiz_answer_pdf_identified doesn't have a listno value. This is the fix for that.